### PR TITLE
Add a way to target files other than bower.json

### DIFF
--- a/npm-bower-sync-ver.js
+++ b/npm-bower-sync-ver.js
@@ -3,24 +3,41 @@
 const fs = require('fs')
 const program = require('commander')
 const meta = require(`${process.cwd()}/package.json`)
+const path = require('path')
+
+const DEFAULT_FILE_PATHS = [ './bower.json' ]
+
+function collect (val, memo) {
+  memo.push(val)
+  return memo
+}
+
+function updateVersion (file, ver) {
+  const resolved = path.resolve(file)
+
+  let fileStr = fs.readFileSync(resolved, 'utf-8')
+  const verPtn = /(.*"version"\s*:\s*")[^"]*(".*)/
+
+  if (verPtn.test(fileStr)) {
+    fileStr = fileStr.replace(verPtn, '$1' + ver + '$2')
+    fs.writeFileSync(resolved, fileStr, 'utf-8')
+  }
+}
 
 try {
   let ver = meta.version
 
   program
     .version(meta.version)
+    .option('-f, --file [file]', 'The target file to sync. Defaults to bower.json', collect, DEFAULT_FILE_PATHS)
     .arguments('<version>')
     .action(v => { ver = v })
     .parse(process.argv)
 
   if (ver) {
-    let fileStr = fs.readFileSync('./bower.json', 'utf-8')
-    const verPtn = /(.*"version"\s*:\s*")[^"]*(".*)/
-
-    if (verPtn.test(fileStr)) {
-      fileStr = fileStr.replace(verPtn, '$1' + ver + '$2')
-      fs.writeFileSync('./bower.json', fileStr, 'utf-8')
-    }
+    program.file.forEach(
+      file => updateVersion(file, ver)
+    )
   }
 
   process.exit(0)


### PR DESCRIPTION
Hi,

We've started using this package since it perfectly suited our needs but now we reached a point where it would be useful to update a different file to bower.json (in this case a composer.json file).

Since the code was simple enough we managed to extend it to provide the ability to specify the target file to change.

Hopefully you can find this useful and add it to the project.